### PR TITLE
releaseIsGitDirectory needs to return 0

### DIFF
--- a/recipe/sentry.php
+++ b/recipe/sentry.php
@@ -138,7 +138,7 @@ EXAMPLE
 
 function releaseIsGitDirectory()
 {
-    return (bool) run('cd {{release_path}} && git rev-parse --git-dir > /dev/null 2>&1 && echo 1');
+    return (bool) run('cd {{release_path}} && git rev-parse --git-dir > /dev/null 2>&1 && echo 1 || echo 0');
 }
 
 function getReleaseGitRef(): Closure


### PR DESCRIPTION
Added || option to releaseIsGitDirectory() so it can return the proper type for the call's declaration. It was failing on a rsync operation because it was not a git repo. This seems to resolve the issue.

| Q             | A
| ------------- | ---
| Bug fix?      | Yes
| New feature?  | No
| BC breaks?    | No
| Deprecations? | No
| Fixed tickets | N/A

> Do not forget to add notes about your changes to [CHANGELOG.md](https://github.com/deployphp/recipes/blob/master/CHANGELOG.md)
